### PR TITLE
Configure fixed NodePort for Prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,13 @@ This repository provisions a Google Kubernetes Engine (GKE) cluster and deploys 
 4. Configure kubectl using `gcloud container clusters get-credentials` and apply the manifests in `k8s/`:
 
    ```bash
-   kubectl apply -f k8s/
-   ```
+    kubectl apply -f k8s/
+    ```
 
 The GitHub Actions workflow performs the same steps automatically on every push.
+
+## Connecting Grafana
+
+Prometheus is exposed via a NodePort service on port `30900`. To connect an
+external Grafana instance, find the external IP of any cluster node and use
+`http://<NODE_IP>:30900` as the Prometheus data source URL.

--- a/k8s/prometheus.yaml
+++ b/k8s/prometheus.yaml
@@ -74,3 +74,4 @@ spec:
   ports:
     - port: 9090
       targetPort: 9090
+      nodePort: 30900


### PR DESCRIPTION
## Summary
- open Prometheus service on a fixed NodePort so external Grafana can easily connect
- document how to connect Grafana to Prometheus

## Testing
- `terraform init` *(fails: terraform not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684dad98f7608331abf9e8ecc4c76ea9